### PR TITLE
ci(luarocks): add --force and --dev args

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -18,3 +18,6 @@ jobs:
           version: "scm"
           dependencies: |
             none-ls.nvim
+          extra_luarocks_args: |
+            --force
+            --dev


### PR DESCRIPTION
- `--dev` Should fix the dependency not being found in the test install
- `--force` Makes sure the upload doesn't fail if there's already an scm-1 version 