### PR TITLE
feat(eslint, eslint_d): added `svelte` and `astro` filetypes

### DIFF
--- a/lua/none-ls/code_actions/eslint.lua
+++ b/lua/none-ls/code_actions/eslint.lua
@@ -148,7 +148,15 @@ return h.make_builtin({
         description = "Injects actions to fix ESLint issues or ignore broken rules.",
     },
     method = CODE_ACTION,
-    filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" },
+    filetypes = {
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact",
+        "vue",
+        "svelte",
+        "astro",
+    },
     generator_opts = {
         command = "eslint",
         format = "json_raw",

--- a/lua/none-ls/diagnostics/eslint.lua
+++ b/lua/none-ls/diagnostics/eslint.lua
@@ -39,7 +39,15 @@ return h.make_builtin({
         description = "A linter for the JavaScript ecosystem.",
     },
     method = DIAGNOSTICS,
-    filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" },
+    filetypes = {
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact",
+        "vue",
+        "svelte",
+        "astro",
+    },
     generator_opts = {
         command = "eslint",
         args = { "-f", "json", "--stdin", "--stdin-filename", "$FILENAME" },

--- a/lua/none-ls/formatting/eslint.lua
+++ b/lua/none-ls/formatting/eslint.lua
@@ -21,6 +21,8 @@ return h.make_builtin({
         "typescript",
         "typescriptreact",
         "vue",
+        "svelte",
+        "astro",
     },
     factory = h.generator_factory,
     generator_opts = {

--- a/lua/none-ls/formatting/eslint_d.lua
+++ b/lua/none-ls/formatting/eslint_d.lua
@@ -21,6 +21,8 @@ return h.make_builtin({
         "typescript",
         "typescriptreact",
         "vue",
+        "svelte",
+        "astro",
     },
     generator_opts = {
         command = "eslint_d",


### PR DESCRIPTION
I was using the filetypes `svelte` and `astro` with `require("none-ls.diagnostics.eslint_d").with({ extra_filetypes = { "astro", "svelte" }})` and it works fine.

I think we should add those in the `filetypes` entry.

> [!note]
> [Eslint lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#eslint) now is updated to work with these filetypes