### PR TITLE
ruff: Add `check` argument (mandatory since 0.5.0)

### DIFF
--- a/lua/none-ls/diagnostics/ruff.lua
+++ b/lua/none-ls/diagnostics/ruff.lua
@@ -61,6 +61,7 @@ return h.make_builtin({
     generator_opts = {
         command = "ruff",
         args = {
+            "check",
             "-n",
             "-e",
             "--stdin-filename",

--- a/lua/none-ls/formatting/ruff.lua
+++ b/lua/none-ls/formatting/ruff.lua
@@ -19,7 +19,15 @@ return h.make_builtin({
     filetypes = { "python" },
     generator_opts = {
         command = "ruff",
-        args = { "--fix", "-e", "-n", "--stdin-filename", "$FILENAME", "-" },
+        args = {
+            "check",
+            "--fix",
+            "-n",
+            "-e",
+            "--stdin-filename",
+            "$FILENAME",
+            "-",
+        },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
As per the [ruff 0.5.0 changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#050):

> The following deprecated CLI commands have been removed:
> `ruff <path>`; use `ruff check <path>`

none-ls-extras.nvim is still using the deprecated CLI syntax.
Without the `check` argument , `diagnostics.ruff` and `format.ruff` builtins will fail with the following error in debug logs:

```
...none-ls.nvim/lua/null-ls/helpers/generator_factory.lua:207: error output: error: `ruff <path>` has been removed. Use `ruff check <path>` instead.
```

This PR adds the `check` argument.