### PR TITLE
fix: eslint_d formatter abilities

### DIFF
--- a/lua/none-ls/formatting/eslint_d.lua
+++ b/lua/none-ls/formatting/eslint_d.lua
@@ -34,7 +34,7 @@ return h.make_builtin({
         end),
         on_output = function(params, done)
             done({ { text = params.output } })
-        end
+        end,
     },
     factory = h.formatter_factory,
 })

--- a/lua/none-ls/formatting/eslint_d.lua
+++ b/lua/none-ls/formatting/eslint_d.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local u = require("null-ls.utils")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
@@ -28,6 +29,12 @@ return h.make_builtin({
         command = "eslint_d",
         args = { "--fix-to-stdout", "--stdin", "--stdin-filename", "$FILENAME" },
         to_stdin = true,
+        cwd = h.cache.by_bufnr(function(params)
+            return u.cosmiconfig("eslint", "eslintConfig")(params.bufname)
+        end),
+        on_output = function(params, done)
+            done({ { text = params.output } })
+        end
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
Original config sadly didn't work for me. I spent some time trying to figure out the reason. After all I fixed an issue and want to share my fix so others who still uses `eslint_d` + `none-ls` will be able to use formatting abilities again