### PR TITLE
ruff: set --output-format=concise

### DIFF
--- a/lua/none-ls/diagnostics/ruff.lua
+++ b/lua/none-ls/diagnostics/ruff.lua
@@ -64,6 +64,7 @@ return h.make_builtin({
             "check",
             "-n",
             "-e",
+            "--output-format=concise",
             "--stdin-filename",
             "$FILENAME",
             "-",


### PR DESCRIPTION
The parsed output depends on this format, so specify it, otherwise user's ruff config can cause the plugin to miss diagnostics.

fixes #17 

`ruff check --output-format=concise` is valid since at least ruff v0.2.0