### PR TITLE
feat: add support for golangci-lint as a Go formatter

### DIFF
--- a/lua/none-ls/formatting/golangci_lint.lua
+++ b/lua/none-ls/formatting/golangci_lint.lua
@@ -1,0 +1,24 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "golangci_lint",
+    meta = {
+        url = "https://golangci-lint.run/",
+        description = "Go formatter using `golangci-lint fmt` command.",
+        notes = {
+            "Requires golangci-lint v2.",
+            "Formatters can be configured in the `formatters` section of `.golangci.yml`.",
+        },
+    },
+    method = FORMATTING,
+    filetypes = { "go" },
+    generator_opts = {
+        command = "golangci-lint",
+        args = { "fmt", "--stdin" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Introduce a new formatter for Go files using `golangci-lint`. This integration leverages the `golangci-lint fmt` command to format Go code. The formatter is configured to read from standard input and supports customization via the `formatters` section in `.golangci.yml`. This addition requires `golangci-lint` version 2 or higher.

Resolves https://github.com/nvimtools/none-ls.nvim/issues/313.

## Testing

Tested manually.