### PR TITLE
feat(formatting): add support for nginx-config-formatter

### DIFF
--- a/lua/none-ls/formatting/nginx_config_formatter.lua
+++ b/lua/none-ls/formatting/nginx_config_formatter.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "nginx-config-formatter",
+    meta = {
+        url = "https://github.com/slomkowski/nginx-config-formatter",
+        description = "nginx config file formatter/beautifier written in Python with no additional dependencies.",
+    },
+    method = FORMATTING,
+    filetypes = { "nginx" },
+    generator_opts = {
+        command = "nginxfmt",
+        args = { "--pipe" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Add configuration for [nginx-config-formatter](https://github.com/slomkowski/nginx-config-formatter)

The motivation for this is that `nginx-config-formatter` is available through mason.
The builtin `nginx_beautifier` is not