### PR TITLE
builtins/alloy: add fmt and validate sources

### DIFF
--- a/lua/none-ls/diagnostics/alloy.lua
+++ b/lua/none-ls/diagnostics/alloy.lua
@@ -1,0 +1,34 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS_ON_SAVE = methods.internal.DIAGNOSTICS_ON_SAVE
+
+return h.make_builtin({
+    name = "alloy_validate",
+    meta = {
+        url = "https://grafana.com/docs/alloy/latest/reference/cli/validate/",
+        description = "Validate Grafana Alloy configuration files using `alloy validate`.",
+    },
+    method = DIAGNOSTICS_ON_SAVE,
+    filetypes = { "alloy" },
+    generator_opts = {
+        command = "alloy",
+        args = { "validate", "$FILENAME" },
+        from_stderr = true,
+        format = "line",
+        on_output = h.diagnostics.from_patterns({
+            {
+                -- Matches: Error: /path/to/file.alloy:10:5: message
+                pattern = [[^(%w+):%s+(.-):(%d+):(%d+):%s+(.*)$]],
+                groups = { "severity", "filename", "row", "col", "message" },
+                overrides = {
+                    severities = {
+                        ["Error"] = h.diagnostics.severities.error,
+                        ["Warning"] = h.diagnostics.severities.warning,
+                    },
+                },
+            },
+        }),
+    },
+    factory = h.generator_factory,
+})

--- a/lua/none-ls/formatting/alloy.lua
+++ b/lua/none-ls/formatting/alloy.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "alloy_fmt",
+    meta = {
+        url = "https://grafana.com/docs/alloy/latest/reference/cli/fmt/",
+        description = "Format Grafana Alloy configuration files using `alloy fmt`.",
+    },
+    method = FORMATTING,
+    filetypes = { "alloy" },
+    generator_opts = {
+        command = "alloy",
+        args = { "fmt" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})

--- a/test/spec/diagnostics/alloy_spec.lua
+++ b/test/spec/diagnostics/alloy_spec.lua
@@ -1,0 +1,39 @@
+local stub = require("luassert.stub")
+
+local alloy = require("none-ls.diagnostics.alloy")
+
+stub(vim, "notify")
+
+describe("diagnostics alloy", function()
+    local parser = alloy._opts.on_output
+
+    it("should create a diagnostic with error severity", function()
+        local line = "Error: /home/user/config.alloy:10:5: unexpected token"
+        local diagnostic = parser(line, {})
+        assert.same({
+            col = "5",
+            filename = "/home/user/config.alloy",
+            message = "unexpected token",
+            row = "10",
+            severity = 1,
+        }, diagnostic)
+    end)
+
+    it("should create a diagnostic with warning severity", function()
+        local line = "Warning: /home/user/config.alloy:3:1: deprecated block usage"
+        local diagnostic = parser(line, {})
+        assert.same({
+            col = "1",
+            filename = "/home/user/config.alloy",
+            message = "deprecated block usage",
+            row = "3",
+            severity = 2,
+        }, diagnostic)
+    end)
+
+    it("should return nil for non-matching lines", function()
+        local line = "  some context line or stack trace"
+        local diagnostic = parser(line, {})
+        assert.is_nil(diagnostic)
+    end)
+end)


### PR DESCRIPTION
Adds two builtins for [Grafana Alloy](https://grafana.com/docs/alloy/latest/) configuration files (`.alloy`):

- `formatting.alloy` — runs `alloy fmt` reading from stdin to format config files
- `diagnostics.alloy` — runs `alloy validate` on save and parses its stderr output to surface errors and warnings as LSP diagnostics

I've been running both of these in my personal NixOS configuration ([britter/nix-configuration](https://github.com/britter/nix-configuration/blob/main/home/terminal/nvim/languages/alloy.nix)) for about half a year and want to contribute them upstream.