### PR TITLE
builtins/jsonnetfmt: add formatting source

### DIFF
--- a/lua/none-ls/formatting/jsonnetfmt.lua
+++ b/lua/none-ls/formatting/jsonnetfmt.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "jsonnetfmt",
+    meta = {
+        url = "https://github.com/google/go-jsonnet",
+        description = "Format Jsonnet files using `jsonnetfmt`.",
+    },
+    method = FORMATTING,
+    filetypes = { "jsonnet" },
+    generator_opts = {
+        command = "jsonnetfmt",
+        args = { "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Adds a `jsonnetfmt` formatting source for Jsonnet files, using `jsonnetfmt -` over stdin.

Require path: `require("none-ls.formatting.jsonnetfmt")`